### PR TITLE
Move from labix.org/v2/mgo to gopkg.in/mgo.v2

### DIFF
--- a/magnate.go
+++ b/magnate.go
@@ -5,7 +5,7 @@ import (
 	"io"
 
 	"github.com/rakyll/pb"
-	"labix.org/v2/mgo"
+	"gopkg.in/mgo.v2"
 )
 
 type Namer interface {


### PR DESCRIPTION
gopkg.in/mgo.v2 is the offical package location.
